### PR TITLE
fix: fix pumpfun tokens pipe and add a new token transfer stream

### DIFF
--- a/pipes/svm/pumpfun_tokens/cli.ts
+++ b/pipes/svm/pumpfun_tokens/cli.ts
@@ -5,9 +5,9 @@ async function main() {
   const logger = createLogger('solana_tokens');
 
   const datasource = new SolanaPumpfunTokensStream({
-    portal: 'https://portal.sqd.dev/datasets/solana-mainnet',
+    portal: 'https://portal.sqd.dev/datasets/solana-beta',
     blockRange: {
-      from: 240_000_000,
+      from: 338227791
     },
     logger,
   });
@@ -19,7 +19,6 @@ async function main() {
       t.accounts.mint;
     });
     logger.info(`--------------`);
-
     // await datasource.ack();
   }
 }

--- a/pipes/svm/transfers/index.ts
+++ b/pipes/svm/transfers/index.ts
@@ -1,0 +1,23 @@
+import { SolanaTokenTransfersStream } from '../../../streams/solana_token_transfers';
+import { createLogger } from '../../utils';
+
+async function main() {
+  const logger = createLogger('solana_tokens');
+
+  const datasource = new SolanaTokenTransfersStream({
+    portal: 'https://portal.sqd.dev/datasets/solana-mainnet',
+    blockRange: {
+      from: 329339129,
+    },
+    logger,
+    args: {
+        wallet: "3TzDbGJ7kfTgorbXXweA21uFLQd6afxLYNTeCcim4zUk",
+    }
+  });
+
+  for await (const it of await datasource.stream()) {
+    logger.info(`--- balance has changed to ${it.newBalance} at ${new Date(it.timestamp * 1000).toLocaleDateString()}`)
+  }
+}
+
+void main();

--- a/streams/solana_token_transfers/index.ts
+++ b/streams/solana_token_transfers/index.ts
@@ -1,0 +1,110 @@
+import { BlockRef, OptionalArgs, PortalAbstractStream } from '../../core/portal_abstract_stream';
+import * as splToken from '../solana_swaps/abi/tokenProgram';
+
+export type SolanaTokenTransfer = {
+    id: string;                    // Unique identifier (transaction hash + instruction address)
+    type: 'transfer';              // Event type
+    direction: 'in' | 'out';       // Direction relative to the wallet
+    account: string;               // Token account owned by the wallet
+    transaction: {
+        hash: string;
+        index: number;
+    };
+    amount: bigint;                // Transfer amount
+    mint: string;                  // Token mint address
+    decimals: number;              // Token decimals
+    counterparty: string;          // Other party in the transfer
+    block: BlockRef;               // Block reference
+    timestamp: Date;               // Transfer timestamp
+    instruction: { address: number[] }; // Instruction address
+};
+
+export class SolanaTokenTransfersStream extends PortalAbstractStream<
+    SolanaTokenTransfer,
+    OptionalArgs<{
+        wallet: string;
+    }>
+> {
+    async stream(): Promise<ReadableStream<SolanaTokenTransfer[]>> {
+        const wallet = this.options.args?.wallet;
+
+        const walletTokenAccount = wallet;
+
+        const source = await this.getStream({
+            type: 'solana',
+            fields: {
+                block: {
+                    number: true,
+                    hash: true,
+                    timestamp: true,
+                },
+                tokenBalance: {
+                    transactionIndex: true,
+                    account: true,
+                    preMint: false,
+                    postMint: true,
+                    postDecimals: false,
+                    preAmount: false,
+                    postAmount: true,
+                },
+            },
+            instructions: [
+                {
+                    programId: [splToken.programId],
+                    isCommitted: true,
+                    transaction: true,
+                    transactionTokenBalances: true,
+                    a0: [walletTokenAccount],
+                    d1: [splToken.instructions.transfer.d1]
+                },
+                {
+                    programId: [splToken.programId],
+                    isCommitted: true,
+                    transaction: true,
+                    transactionTokenBalances: true,
+                    a1: [walletTokenAccount],
+                    d1: [splToken.instructions.transfer.d1]
+                },
+                {
+                    programId: [splToken.programId],
+                    isCommitted: true,
+                    transaction: true,
+                    transactionTokenBalances: true,
+                    a0: [walletTokenAccount],
+                    d1: [splToken.instructions.transferChecked.d1]
+                },
+                {
+                    programId: [splToken.programId],
+                    isCommitted: true,
+                    transaction: true,
+                    transactionTokenBalances: true,
+                    a2: [walletTokenAccount],
+                    d1: [splToken.instructions.transferChecked.d1]
+                },
+            ]
+
+        });
+
+        return source.pipeThrough(
+            new TransformStream({
+                transform: (data, controller) => {
+                    const { blocks } = data;
+                    const transfers: SolanaTokenTransfer[] = [];
+
+                    for (const block of blocks) {
+                        if (block.tokenBalances) {
+                            for (const balance of block.tokenBalances) {
+                                if (balance.account == walletTokenAccount) {
+                                    controller.enqueue({
+                                        timestamp: block.header.timestamp,
+                                        newBalance: balance['postAmount']
+                                    });
+                                }
+                            }
+                        }
+                    }
+                },
+            }),
+        );
+    }
+}


### PR DESCRIPTION
- Update Solana Pumpfun Tokens Stream to use the 'solana-beta' dataset and a new starting block.
- Introduce a new stream, `SolanaTokenTransfersStream`, to track token transfers for a specified wallet.